### PR TITLE
use view mode for taskwarrior info

### DIFF
--- a/taskwarrior.el
+++ b/taskwarrior.el
@@ -181,7 +181,9 @@
     (progn
       (switch-to-buffer-other-window buf)
       (erase-buffer)
-      (insert (taskwarrior--shell-command "info" id)))))
+      (insert (taskwarrior--shell-command "info" id))
+      (view-mode 1)
+      (setq view-exit-action 'kill-buffer))))
 
 (defun taskwarrior--parse-created-task-id (output)
   "Extract task id from shell OUTPUT of `task add`."


### PR DESCRIPTION
Currently when I press enter, I enter the buffer `*taskwarrior info*` which is editable, and it does not actually work like `task 1 edit`. I think we may use `view-mode` for that buffer to disallow users to edit the buffer because it is pointless to edit the buffer. Maybe we should bind enter to a command like `task 1 edit`. What is your thought?