### PR TITLE
Changed the default export command to only show pending tasks

### DIFF
--- a/taskwarrior.el
+++ b/taskwarrior.el
@@ -279,7 +279,7 @@
       (setq tabulated-list-entries
 	    (if taskwarrior-active-filter
 		(taskwarrior-export taskwarrior-active-filter)
-	      (taskwarrior-export)))
+	      (taskwarrior-export "status=pending")))
       (tabulated-list-print t)))
 
 (defun taskwarrior-export-task (id)


### PR DESCRIPTION
Previously, the taskwarrior mode also showed the parents of my recurring tasks. This is not the case anymore with this PR.